### PR TITLE
set max size for picture questions. updated immediate correction.

### DIFF
--- a/src/main/webapp/create_quiz.jsp
+++ b/src/main/webapp/create_quiz.jsp
@@ -38,6 +38,26 @@
         document.documentElement.classList.remove('light-mode');
         document.body.classList.remove('light-mode');
       }
+
+      // Immediate Correction logic
+      const isOnePageCheckbox = document.querySelector('input[name="isOnePage"]');
+      const immediateCorrectionCheckbox = document.querySelector('input[name="immediateCorrection"]');
+      const immediateCorrectionLabel = immediateCorrectionCheckbox.closest('label');
+
+      function updateImmediateCorrectionState() {
+        if (isOnePageCheckbox.checked) {
+          immediateCorrectionCheckbox.checked = false;
+          immediateCorrectionCheckbox.disabled = true;
+          immediateCorrectionLabel.title = 'Immediate correction is only available for multiple pages quizzes.';
+          immediateCorrectionLabel.style.opacity = '0.6';
+        } else {
+          immediateCorrectionCheckbox.disabled = false;
+          immediateCorrectionLabel.title = '';
+          immediateCorrectionLabel.style.opacity = '1';
+        }
+      }
+      isOnePageCheckbox.addEventListener('change', updateImmediateCorrectionState);
+      updateImmediateCorrectionState();
     });
     </script>
     <meta charset="UTF-8">

--- a/src/main/webapp/css/take_quiz.css
+++ b/src/main/webapp/css/take_quiz.css
@@ -167,13 +167,16 @@ button:hover, .submit-btn:hover, input[type="submit"]:hover {
 } 
 
 .question-image {
-  width: 300px !important;
-  height: 200px !important;
-  object-fit: cover !important;
-  display: block !important;
-  margin: 16px auto !important;
-  border-radius: 8px !important;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.08) !important;
+  max-width: 350px;
+  max-height: 220px;
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+  display: block;
+  margin: 16px auto;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.08);
+  background: #181848;
 }
 
 /* Fill-in-the-blank specific styles */


### PR DESCRIPTION
Set max size for pictures so that they don't take the whole screen when getting displayed. Also made the changes which enables us to use immediate correction only when we choose to create the quiz in the multiple-pages style.